### PR TITLE
Request necessary privileged intent on bot connect

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -10,7 +10,9 @@ MC_ADMIN_ROLE = os.getenv('DISCORD_ADMIN_ROLE_ID')
 MINECRAFT_INSTANCE_ID = os.getenv('MINECRAFT_INSTANCE_ID')
 REGION = os.getenv('AWS_REGION')
 
-client = discord.Client()
+intents = discord.Intents.default()
+intents.members = True
+client = discord.Client(intents=intents)
 
 @client.event
 async def on_ready():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ attrs==19.3.0
 boto3==1.13.16
 botocore==1.16.16
 chardet==3.0.4
-discord.py==1.3.3
+discord.py==1.5.1
 docutils==0.15.2
 idna==2.9
 jmespath==0.10.0


### PR DESCRIPTION
https://discordpy.readthedocs.io/en/latest/intents.html#where-d-my-members-go

Discord made a breaking API change that requires this change for admin role lookup to work.